### PR TITLE
change input views 1-8

### DIFF
--- a/ui/web/js/main.js
+++ b/ui/web/js/main.js
@@ -134,11 +134,11 @@ window.Router = Backbone.Router.extend({
     },
 
     Input6: function() {
-        this.renderInput(this.Input2View, 'Input6');
+        this.renderInput(this.Input6View, 'Input6');
     },
 
     Input7: function() {
-        this.renderInput(this.Input2View, 'Input7');
+        this.renderInput(this.Input7View, 'Input7');
     },
 
     Input8: function() {

--- a/ui/web/js/views/input1.js
+++ b/ui/web/js/views/input1.js
@@ -7,23 +7,21 @@ window.Input1View = window.InputBaseView.extend({
 
     events : {
         // "change #lang": "changeLang",
-        "change .cassette-type":"handleCassetteChange", // casette change
-        "click #openFoup":"openFoupBtnCLick",           // open foup
-        "click #closeFoup":"closeFoupBtnCLick",         // close foup
-        "click #loadCasette":"loadCasetteBtnCLick",     // load casette
-        "click #unloadCasette":"unloadCasetteBtnCLick", // unload casette
-        "click #openDoor":"openDoorBtnCLick",           // open door
-        "click #closeDoor":"closeDoorBtnCLick",         // close door
-        "click #restoreData":"restoreDataBtnCLick",     // restore data
-        "click #getStandard":"getStandardBtnCLick",     // get standard
-        "click #putStandard":"putStandardBtnCLick",     // put standard
-        "click #mapStandard":"mapStandardBtnCLick",     // map standard
-        "click #getWrapBelow":"getWrapBelowBtnCLick",   // get wrap below
-        "click #putWrapBelow":"putWrapBelowBtnCLick",   // put wrap below
-        "click #mapWrapBelow":"mapWrapBelowBtnCLick",   // map wrap below
-        "click #getWrapAbove":"getWrapAboveBtnCLick",   // get wrap above
-        "click #putWrapAbove":"putWrapAboveBtnCLick",   // put wrap above
-        "click #mapWrapAbove":"mapWrapAboveBtnCLick",   // map wrap above
-        "click #slots tr > td":"slotClick"              // slot click
+        "change #waferType":"handleWaferTypeChange",      // change wafer type
+        "change .cassette-type":"handleCassetteChange",   // casette change
+        "click #openFoup":"openFoupBtnCLick",             // open foup
+        "click #closeFoup":"closeFoupBtnCLick",           // close foup
+        "click #loadCasette":"loadCasetteBtnCLick",       // load casette
+        "click #unloadCasette":"unloadCasetteBtnCLick",   // unload casette
+        "click #openDoor":"openDoorBtnCLick",             // open door
+        "click #closeDoor":"closeDoorBtnCLick",           // close door
+        "click #restoreData":"restoreDataBtnCLick",       // restore data
+        "click #updateId":"updateIdBtnCLick",             // update ID
+        "click #getWaferType":"getWaferTypeBtnCLick",     // get standard
+        "click #putWaferType":"putWaferTypeBtnCLick",     // put standard
+        "click #mapWaferType":"mapWaferTypeBtnCLick",     // map standard
+        "click #slots tr > td":"slotClick",               // slot click
+        "dblclick #slots tr > th":"slotIdDblCkick",       // slot id double click
+        "focusout .wafer-id-input":"handleWaferIdChange"  // wafer id change
     }
 });

--- a/ui/web/js/views/input1.js
+++ b/ui/web/js/views/input1.js
@@ -20,8 +20,8 @@ window.Input1View = window.InputBaseView.extend({
         "click #getWaferType":"getWaferTypeBtnCLick",     // get standard
         "click #putWaferType":"putWaferTypeBtnCLick",     // put standard
         "click #mapWaferType":"mapWaferTypeBtnCLick",     // map standard
+        "dblclick #slots tr > td":"slotIdDblCkick",       // slot id double click
         "click #slots tr > td":"slotClick",               // slot click
-        "dblclick #slots tr > th":"slotIdDblCkick",       // slot id double click
         "focusout .wafer-id-input":"handleWaferIdChange"  // wafer id change
     }
 });

--- a/ui/web/js/views/input2.js
+++ b/ui/web/js/views/input2.js
@@ -7,23 +7,21 @@ window.Input2View = window.InputBaseView.extend({
 
     events : {
         // "change #lang": "changeLang",
-        "change .cassette-type":"handleCassetteChange", // casette change
-        "click #openFoup":"openFoupBtnCLick",           // open foup
-        "click #closeFoup":"closeFoupBtnCLick",         // close foup
-        "click #loadCasette":"loadCasetteBtnCLick",     // load casette
-        "click #unloadCasette":"unloadCasetteBtnCLick", // unload casette
-        "click #openDoor":"openDoorBtnCLick",           // open door
-        "click #closeDoor":"closeDoorBtnCLick",         // close door
-        "click #restoreData":"restoreDataBtnCLick",     // restore data
-        "click #getStandard":"getStandardBtnCLick",     // get standard
-        "click #putStandard":"putStandardBtnCLick",     // put standard
-        "click #mapStandard":"mapStandardBtnCLick",     // map standard
-        "click #getWrapBelow":"getWrapBelowBtnCLick",   // get wrap below
-        "click #putWrapBelow":"putWrapBelowBtnCLick",   // put wrap below
-        "click #mapWrapBelow":"mapWrapBelowBtnCLick",   // map wrap below
-        "click #getWrapAbove":"getWrapAboveBtnCLick",   // get wrap above
-        "click #putWrapAbove":"putWrapAboveBtnCLick",   // put wrap above
-        "click #mapWrapAbove":"mapWrapAboveBtnCLick",   // map wrap above
-        "click #slots tr > td":"slotClick"              // slot click
+        "change #waferType":"handleWaferTypeChange",      // change wafer type
+        "change .cassette-type":"handleCassetteChange",   // casette change
+        "click #openFoup":"openFoupBtnCLick",             // open foup
+        "click #closeFoup":"closeFoupBtnCLick",           // close foup
+        "click #loadCasette":"loadCasetteBtnCLick",       // load casette
+        "click #unloadCasette":"unloadCasetteBtnCLick",   // unload casette
+        "click #openDoor":"openDoorBtnCLick",             // open door
+        "click #closeDoor":"closeDoorBtnCLick",           // close door
+        "click #restoreData":"restoreDataBtnCLick",       // restore data
+        "click #updateId":"updateIdBtnCLick",             // update ID
+        "click #getWaferType":"getWaferTypeBtnCLick",     // get standard
+        "click #putWaferType":"putWaferTypeBtnCLick",     // put standard
+        "click #mapWaferType":"mapWaferTypeBtnCLick",     // map standard
+        "dblclick #slots tr > td":"slotIdDblCkick",       // slot id double click
+        "click #slots tr > td":"slotClick",               // slot click
+        "focusout .wafer-id-input":"handleWaferIdChange"  // wafer id change
     }
 });

--- a/ui/web/js/views/input3.js
+++ b/ui/web/js/views/input3.js
@@ -7,23 +7,21 @@ window.Input3View = window.InputBaseView.extend({
 
     events : {
         // "change #lang": "changeLang",
-        "change .cassette-type":"handleCassetteChange", // casette change
-        "click #openFoup":"openFoupBtnCLick",           // open foup
-        "click #closeFoup":"closeFoupBtnCLick",         // close foup
-        "click #loadCasette":"loadCasetteBtnCLick",     // load casette
-        "click #unloadCasette":"unloadCasetteBtnCLick", // unload casette
-        "click #openDoor":"openDoorBtnCLick",           // open door
-        "click #closeDoor":"closeDoorBtnCLick",         // close door
-        "click #restoreData":"restoreDataBtnCLick",     // restore data
-        "click #getStandard":"getStandardBtnCLick",     // get standard
-        "click #putStandard":"putStandardBtnCLick",     // put standard
-        "click #mapStandard":"mapStandardBtnCLick",     // map standard
-        "click #getWrapBelow":"getWrapBelowBtnCLick",   // get wrap below
-        "click #putWrapBelow":"putWrapBelowBtnCLick",   // put wrap below
-        "click #mapWrapBelow":"mapWrapBelowBtnCLick",   // map wrap below
-        "click #getWrapAbove":"getWrapAboveBtnCLick",   // get wrap above
-        "click #putWrapAbove":"putWrapAboveBtnCLick",   // put wrap above
-        "click #mapWrapAbove":"mapWrapAboveBtnCLick",   // map wrap above
-        "click #slots tr > td":"slotClick"              // slot click
+        "change #waferType":"handleWaferTypeChange",      // change wafer type
+        "change .cassette-type":"handleCassetteChange",   // casette change
+        "click #openFoup":"openFoupBtnCLick",             // open foup
+        "click #closeFoup":"closeFoupBtnCLick",           // close foup
+        "click #loadCasette":"loadCasetteBtnCLick",       // load casette
+        "click #unloadCasette":"unloadCasetteBtnCLick",   // unload casette
+        "click #openDoor":"openDoorBtnCLick",             // open door
+        "click #closeDoor":"closeDoorBtnCLick",           // close door
+        "click #restoreData":"restoreDataBtnCLick",       // restore data
+        "click #updateId":"updateIdBtnCLick",             // update ID
+        "click #getWaferType":"getWaferTypeBtnCLick",     // get standard
+        "click #putWaferType":"putWaferTypeBtnCLick",     // put standard
+        "click #mapWaferType":"mapWaferTypeBtnCLick",     // map standard
+        "dblclick #slots tr > td":"slotIdDblCkick",       // slot id double click
+        "click #slots tr > td":"slotClick",               // slot click
+        "focusout .wafer-id-input":"handleWaferIdChange"  // wafer id change
     }
 });

--- a/ui/web/js/views/input4.js
+++ b/ui/web/js/views/input4.js
@@ -7,23 +7,21 @@ window.Input4View = window.InputBaseView.extend({
 
     events : {
         // "change #lang": "changeLang",
-        "change .cassette-type":"handleCassetteChange", // casette change
-        "click #openFoup":"openFoupBtnCLick",           // open foup
-        "click #closeFoup":"closeFoupBtnCLick",         // close foup
-        "click #loadCasette":"loadCasetteBtnCLick",     // load casette
-        "click #unloadCasette":"unloadCasetteBtnCLick", // unload casette
-        "click #openDoor":"openDoorBtnCLick",           // open door
-        "click #closeDoor":"closeDoorBtnCLick",         // close door
-        "click #restoreData":"restoreDataBtnCLick",     // restore data
-        "click #getStandard":"getStandardBtnCLick",     // get standard
-        "click #putStandard":"putStandardBtnCLick",     // put standard
-        "click #mapStandard":"mapStandardBtnCLick",     // map standard
-        "click #getWrapBelow":"getWrapBelowBtnCLick",   // get wrap below
-        "click #putWrapBelow":"putWrapBelowBtnCLick",   // put wrap below
-        "click #mapWrapBelow":"mapWrapBelowBtnCLick",   // map wrap below
-        "click #getWrapAbove":"getWrapAboveBtnCLick",   // get wrap above
-        "click #putWrapAbove":"putWrapAboveBtnCLick",   // put wrap above
-        "click #mapWrapAbove":"mapWrapAboveBtnCLick",   // map wrap above
-        "click #slots tr > td":"slotClick"              // slot click
+        "change #waferType":"handleWaferTypeChange",      // change wafer type
+        "change .cassette-type":"handleCassetteChange",   // casette change
+        "click #openFoup":"openFoupBtnCLick",             // open foup
+        "click #closeFoup":"closeFoupBtnCLick",           // close foup
+        "click #loadCasette":"loadCasetteBtnCLick",       // load casette
+        "click #unloadCasette":"unloadCasetteBtnCLick",   // unload casette
+        "click #openDoor":"openDoorBtnCLick",             // open door
+        "click #closeDoor":"closeDoorBtnCLick",           // close door
+        "click #restoreData":"restoreDataBtnCLick",       // restore data
+        "click #updateId":"updateIdBtnCLick",             // update ID
+        "click #getWaferType":"getWaferTypeBtnCLick",     // get standard
+        "click #putWaferType":"putWaferTypeBtnCLick",     // put standard
+        "click #mapWaferType":"mapWaferTypeBtnCLick",     // map standard
+        "dblclick #slots tr > td":"slotIdDblCkick",       // slot id double click
+        "click #slots tr > td":"slotClick",               // slot click
+        "focusout .wafer-id-input":"handleWaferIdChange"  // wafer id change
     }
 });

--- a/ui/web/js/views/input5.js
+++ b/ui/web/js/views/input5.js
@@ -7,24 +7,22 @@ window.Input5View = window.InputBaseView.extend({
 
     events : {
         // "change #lang": "changeLang",
-        "change .cassette-type":"handleCassetteChange", // casette change
-        "click #openFoup":"openFoupBtnCLick",           // open foup
-        "click #closeFoup":"closeFoupBtnCLick",         // close foup
-        "click #loadCasette":"loadCasetteBtnCLick",     // load casette
-        "click #unloadCasette":"unloadCasetteBtnCLick", // unload casette
-        "click #openDoor":"openDoorBtnCLick",           // open door
-        "click #closeDoor":"closeDoorBtnCLick",         // close door
-        "click #restoreData":"restoreDataBtnCLick",     // restore data
-        "click #getStandard":"getStandardBtnCLick",     // get standard
-        "click #putStandard":"putStandardBtnCLick",     // put standard
-        "click #mapStandard":"mapStandardBtnCLick",     // map standard
-        "click #getWrapBelow":"getWrapBelowBtnCLick",   // get wrap below
-        "click #putWrapBelow":"putWrapBelowBtnCLick",   // put wrap below
-        "click #mapWrapBelow":"mapWrapBelowBtnCLick",   // map wrap below
-        "click #getWrapAbove":"getWrapAboveBtnCLick",   // get wrap above
-        "click #putWrapAbove":"putWrapAboveBtnCLick",   // put wrap above
-        "click #mapWrapAbove":"mapWrapAboveBtnCLick",   // map wrap above
-        "click #slots tr > td":"slotClick"              // slot click
+        "change #waferType":"handleWaferTypeChange",      // change wafer type
+        "change .cassette-type":"handleCassetteChange",   // casette change
+        "click #openFoup":"openFoupBtnCLick",             // open foup
+        "click #closeFoup":"closeFoupBtnCLick",           // close foup
+        "click #loadCasette":"loadCasetteBtnCLick",       // load casette
+        "click #unloadCasette":"unloadCasetteBtnCLick",   // unload casette
+        "click #openDoor":"openDoorBtnCLick",             // open door
+        "click #closeDoor":"closeDoorBtnCLick",           // close door
+        "click #restoreData":"restoreDataBtnCLick",       // restore data
+        "click #updateId":"updateIdBtnCLick",             // update ID
+        "click #getWaferType":"getWaferTypeBtnCLick",     // get standard
+        "click #putWaferType":"putWaferTypeBtnCLick",     // put standard
+        "click #mapWaferType":"mapWaferTypeBtnCLick",     // map standard
+        "dblclick #slots tr > td":"slotIdDblCkick",       // slot id double click
+        "click #slots tr > td":"slotClick",               // slot click
+        "focusout .wafer-id-input":"handleWaferIdChange"  // wafer id change
     }
 
 });

--- a/ui/web/js/views/input6.js
+++ b/ui/web/js/views/input6.js
@@ -7,23 +7,21 @@ window.Input6View = window.InputBaseView.extend({
 
     events : {
         // "change #lang": "changeLang",
-        "change .cassette-type":"handleCassetteChange", // casette change
-        "click #openFoup":"openFoupBtnCLick",           // open foup
-        "click #closeFoup":"closeFoupBtnCLick",         // close foup
-        "click #loadCasette":"loadCasetteBtnCLick",     // load casette
-        "click #unloadCasette":"unloadCasetteBtnCLick", // unload casette
-        "click #openDoor":"openDoorBtnCLick",           // open door
-        "click #closeDoor":"closeDoorBtnCLick",         // close door
-        "click #restoreData":"restoreDataBtnCLick",     // restore data
-        "click #getStandard":"getStandardBtnCLick",     // get standard
-        "click #putStandard":"putStandardBtnCLick",     // put standard
-        "click #mapStandard":"mapStandardBtnCLick",     // map standard
-        "click #getWrapBelow":"getWrapBelowBtnCLick",   // get wrap below
-        "click #putWrapBelow":"putWrapBelowBtnCLick",   // put wrap below
-        "click #mapWrapBelow":"mapWrapBelowBtnCLick",   // map wrap below
-        "click #getWrapAbove":"getWrapAboveBtnCLick",   // get wrap above
-        "click #putWrapAbove":"putWrapAboveBtnCLick",   // put wrap above
-        "click #mapWrapAbove":"mapWrapAboveBtnCLick",   // map wrap above
-        "click #slots tr > td":"slotClick"              // slot click
+        "change #waferType":"handleWaferTypeChange",      // change wafer type
+        "change .cassette-type":"handleCassetteChange",   // casette change
+        "click #openFoup":"openFoupBtnCLick",             // open foup
+        "click #closeFoup":"closeFoupBtnCLick",           // close foup
+        "click #loadCasette":"loadCasetteBtnCLick",       // load casette
+        "click #unloadCasette":"unloadCasetteBtnCLick",   // unload casette
+        "click #openDoor":"openDoorBtnCLick",             // open door
+        "click #closeDoor":"closeDoorBtnCLick",           // close door
+        "click #restoreData":"restoreDataBtnCLick",       // restore data
+        "click #updateId":"updateIdBtnCLick",             // update ID
+        "click #getWaferType":"getWaferTypeBtnCLick",     // get standard
+        "click #putWaferType":"putWaferTypeBtnCLick",     // put standard
+        "click #mapWaferType":"mapWaferTypeBtnCLick",     // map standard
+        "dblclick #slots tr > td":"slotIdDblCkick",       // slot id double click
+        "click #slots tr > td":"slotClick",               // slot click
+        "focusout .wafer-id-input":"handleWaferIdChange"  // wafer id change
     }
 });

--- a/ui/web/js/views/input7.js
+++ b/ui/web/js/views/input7.js
@@ -7,23 +7,21 @@ window.Input7View = window.InputBaseView.extend({
 
     events : {
         // "change #lang": "changeLang",
-        "change .cassette-type":"handleCassetteChange", // casette change
-        "click #openFoup":"openFoupBtnCLick",           // open foup
-        "click #closeFoup":"closeFoupBtnCLick",         // close foup
-        "click #loadCasette":"loadCasetteBtnCLick",     // load casette
-        "click #unloadCasette":"unloadCasetteBtnCLick", // unload casette
-        "click #openDoor":"openDoorBtnCLick",           // open door
-        "click #closeDoor":"closeDoorBtnCLick",         // close door
-        "click #restoreData":"restoreDataBtnCLick",     // restore data
-        "click #getStandard":"getStandardBtnCLick",     // get standard
-        "click #putStandard":"putStandardBtnCLick",     // put standard
-        "click #mapStandard":"mapStandardBtnCLick",     // map standard
-        "click #getWrapBelow":"getWrapBelowBtnCLick",   // get wrap below
-        "click #putWrapBelow":"putWrapBelowBtnCLick",   // put wrap below
-        "click #mapWrapBelow":"mapWrapBelowBtnCLick",   // map wrap below
-        "click #getWrapAbove":"getWrapAboveBtnCLick",   // get wrap above
-        "click #putWrapAbove":"putWrapAboveBtnCLick",   // put wrap above
-        "click #mapWrapAbove":"mapWrapAboveBtnCLick",   // map wrap above
-        "click #slots tr > td":"slotClick"              // slot click
+        "change #waferType":"handleWaferTypeChange",      // change wafer type
+        "change .cassette-type":"handleCassetteChange",   // casette change
+        "click #openFoup":"openFoupBtnCLick",             // open foup
+        "click #closeFoup":"closeFoupBtnCLick",           // close foup
+        "click #loadCasette":"loadCasetteBtnCLick",       // load casette
+        "click #unloadCasette":"unloadCasetteBtnCLick",   // unload casette
+        "click #openDoor":"openDoorBtnCLick",             // open door
+        "click #closeDoor":"closeDoorBtnCLick",           // close door
+        "click #restoreData":"restoreDataBtnCLick",       // restore data
+        "click #updateId":"updateIdBtnCLick",             // update ID
+        "click #getWaferType":"getWaferTypeBtnCLick",     // get standard
+        "click #putWaferType":"putWaferTypeBtnCLick",     // put standard
+        "click #mapWaferType":"mapWaferTypeBtnCLick",     // map standard
+        "dblclick #slots tr > td":"slotIdDblCkick",       // slot id double click
+        "click #slots tr > td":"slotClick",               // slot click
+        "focusout .wafer-id-input":"handleWaferIdChange"  // wafer id change
     }
 });

--- a/ui/web/js/views/input8.js
+++ b/ui/web/js/views/input8.js
@@ -7,23 +7,21 @@ window.Input8View = window.InputBaseView.extend({
 
     events : {
         // "change #lang": "changeLang",
-        "change .cassette-type":"handleCassetteChange", // casette change
-        "click #openFoup":"openFoupBtnCLick",           // open foup
-        "click #closeFoup":"closeFoupBtnCLick",         // close foup
-        "click #loadCasette":"loadCasetteBtnCLick",     // load casette
-        "click #unloadCasette":"unloadCasetteBtnCLick", // unload casette
-        "click #openDoor":"openDoorBtnCLick",           // open door
-        "click #closeDoor":"closeDoorBtnCLick",         // close door
-        "click #restoreData":"restoreDataBtnCLick",     // restore data
-        "click #getStandard":"getStandardBtnCLick",     // get standard
-        "click #putStandard":"putStandardBtnCLick",     // put standard
-        "click #mapStandard":"mapStandardBtnCLick",     // map standard
-        "click #getWrapBelow":"getWrapBelowBtnCLick",   // get wrap below
-        "click #putWrapBelow":"putWrapBelowBtnCLick",   // put wrap below
-        "click #mapWrapBelow":"mapWrapBelowBtnCLick",   // map wrap below
-        "click #getWrapAbove":"getWrapAboveBtnCLick",   // get wrap above
-        "click #putWrapAbove":"putWrapAboveBtnCLick",   // put wrap above
-        "click #mapWrapAbove":"mapWrapAboveBtnCLick",   // map wrap above
-        "click #slots tr > td":"slotClick"              // slot click
+        "change #waferType":"handleWaferTypeChange",      // change wafer type
+        "change .cassette-type":"handleCassetteChange",   // casette change
+        "click #openFoup":"openFoupBtnCLick",             // open foup
+        "click #closeFoup":"closeFoupBtnCLick",           // close foup
+        "click #loadCasette":"loadCasetteBtnCLick",       // load casette
+        "click #unloadCasette":"unloadCasetteBtnCLick",   // unload casette
+        "click #openDoor":"openDoorBtnCLick",             // open door
+        "click #closeDoor":"closeDoorBtnCLick",           // close door
+        "click #restoreData":"restoreDataBtnCLick",       // restore data
+        "click #updateId":"updateIdBtnCLick",             // update ID
+        "click #getWaferType":"getWaferTypeBtnCLick",     // get standard
+        "click #putWaferType":"putWaferTypeBtnCLick",     // put standard
+        "click #mapWaferType":"mapWaferTypeBtnCLick",     // map standard
+        "dblclick #slots tr > td":"slotIdDblCkick",       // slot id double click
+        "click #slots tr > td":"slotClick",               // slot click
+        "focusout .wafer-id-input":"handleWaferIdChange"  // wafer id change
     }
 });

--- a/ui/web/js/views/inputBase.js
+++ b/ui/web/js/views/inputBase.js
@@ -131,7 +131,11 @@ window.InputBaseView = window.BaseView.extend({
 
     updateIdBtnCLick: function () {
         // TODO
-        console.log("updateIdBtnCLick");
+        var waferIDArray = new Array();
+        $(".wafer-id").each(function(){
+            waferIDArray.push($(this).text());
+        });
+        console.log("updateIdBtnCLick. id:" + waferIDArray.toString());
     },
 
     getWaferTypeBtnCLick: function () {
@@ -178,92 +182,6 @@ window.InputBaseView = window.BaseView.extend({
         this.ajaxCall(this.ajaxUrl, json, "mapStandard", this.callBack);
     },
 
-    // To be removed after wafer type change for all input view.
-    // START >>
-    getStandardBtnCLick: function () {
-        // Build up JSON
-        if (this.slotTarget !== null) {
-            var slotindex = this.slotTarget.siblings('th').text();
-            var mapparam = {
-                    "index": Number(slotindex),
-                    "status": null,
-                    "waferID": null
-                };
-            var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), "GETSTANDARD", mapparam, null);
-            // AJAX POST
-            this.ajaxCall(this.ajaxUrl, json, "getStandard", this.callBack);
-        } else {
-            alert("Slot select fail.");
-        }
-    },
-
-    putStandardBtnCLick: function () {
-        // Build up JSON
-        if (this.slotTarget !== null) {
-            var slotindex = this.slotTarget.siblings('th').text();
-            var mapparam = {
-                    "index": Number(slotindex),
-                    "status": null,
-                    "waferID": null
-                };
-            var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), "PUTSTANDARD", mapparam, null);
-            // AJAX POST
-            this.ajaxCall(this.ajaxUrl, json, "putStandard", this.callBack);
-        } else {
-            alert("Slot select fail.");
-        }
-    },
-
-    mapStandardBtnCLick: function () {
-        // Build up JSON
-        var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), "MAPSTANDARD", null, null);
-        // AJAX POST
-        this.ajaxCall(this.ajaxUrl, json, "mapStandard", this.callBack);
-    },
-
-    getWrapBelowBtnCLick: function () {
-        // Build up JSON
-        var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), "GETWRAPBELOW", null, null);
-        // AJAX POST
-        this.ajaxCall(this.ajaxUrl, json, "getWrapBelow", this.callBack);
-    },
-
-    putWrapBelowBtnCLick: function () {
-        // Build up JSON
-        var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), "PUTWRAPBELOW", null, null);
-        // AJAX POST
-        this.ajaxCall(this.ajaxUrl, json, "putWrapBelow", this.callBack);
-    },
-
-    mapWrapBelowBtnCLick: function () {
-        // Build up JSON
-        var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), "MAPWRAPBELOW", null, null);
-        // AJAX POST
-        this.ajaxCall(this.ajaxUrl, json, "mapWrapBelow", this.callBack);
-    },
-
-    getWrapAboveBtnCLick: function () {
-        // Build up JSON
-        var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), "GETWRAPABOVE", null, null);
-        // AJAX POST
-        this.ajaxCall(this.ajaxUrl, json, "getWrapAbove", this.callBack);
-    },
-
-    putWrapAboveBtnCLick: function () {
-        // Build up JSON
-        var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), "PUTWRAPABOVE", null, null);
-        // AJAX POST
-        this.ajaxCall(this.ajaxUrl, json, "putWrapAbove", this.callBack);
-    },
-
-    mapWrapAboveBtnCLick: function () {
-        // Build up JSON
-        var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), "MAPWRAPABOVE", null, null);
-        // AJAX POST
-        this.ajaxCall(this.ajaxUrl, json, "mapWrapAbove", this.callBack);
-    },
-    // END <<
-
     slotClick: function (e) {
         this.slotTarget = $(e.currentTarget);
         var selected_slot = this.slotTarget.parent().parent().children();
@@ -279,24 +197,18 @@ window.InputBaseView = window.BaseView.extend({
     },
 
     slotIdDblCkick: function(e) {
-        var th = $(e.currentTarget);
-        th.find('label').hide();
-        th.find('input[type="text"]').show().focus();
-    },
-
-    slotIdDblCkick: function(e) {
-        var th = $(e.currentTarget);
-        th.find('.wafer-id').hide();
-        th.find('.wafer-id-input').val(th.find('.wafer-id').text());
-        th.find('.wafer-id-input').show().focus();
-        th.find('.wafer-id-input').select();
+        var td = $(e.currentTarget);
+        td.find('.wafer-id').hide();
+        td.find('.wafer-id-input').val(td.find('.wafer-id').text());
+        td.find('.wafer-id-input').show().focus();
+        td.find('.wafer-id-input').select();
     },
 
     handleWaferIdChange: function(e) {
         var text = $(e.currentTarget);
         text.hide();
-        var th = $(e.currentTarget).parent();
-        th.find('.wafer-id').text(text.val());
-        th.find('.wafer-id').show();
+        var td = $(e.currentTarget).parent();
+        td.find('.wafer-id').text(text.val());
+        td.find('.wafer-id').show();
     }
 });

--- a/ui/web/js/views/inputBase.js
+++ b/ui/web/js/views/inputBase.js
@@ -11,6 +11,16 @@ window.InputBaseView = window.BaseView.extend({
         // this.stationID = 
     },
 
+    handleWaferTypeChange: function() {
+        var waferType = $("#waferType").val();
+        $("#getWaferTypeLabel").text("GET " + waferType);
+        $("#getWaferType").text("GET " + waferType);
+        $("#putWaferTypeLabel").text("PUT " + waferType);
+        $("#putWaferType").text("PUT " + waferType);
+        $("#mapWaferTypeLabel").text("MAP " + waferType);
+        $("#mapWaferType").text("MAP " + waferType);
+    },
+
     handleCassetteChange: function() {
         console.log("handleCassetteChange");
     },
@@ -119,6 +129,57 @@ window.InputBaseView = window.BaseView.extend({
         this.ajaxCall(this.ajaxUrl, json, "restoreData", this.callBack);
     },
 
+    updateIdBtnCLick: function () {
+        // TODO
+        console.log("updateIdBtnCLick");
+    },
+
+    getWaferTypeBtnCLick: function () {
+        // Build up JSON
+        if (this.slotTarget !== null) {
+            var slotindex = this.slotTarget.siblings('th').text();
+            var mapparam = {
+                    "index": Number(slotindex),
+                    "status": null,
+                    "waferID": null
+                };
+            var action = "GET" + $("#waferType").val();
+            var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), action, mapparam, null);
+            // AJAX POST
+            this.ajaxCall(this.ajaxUrl, json, "getStandard", this.callBack);
+        } else {
+            alert("Slot select fail.");
+        }
+    },
+
+    putWaferTypeBtnCLick: function () {
+        // Build up JSON
+        if (this.slotTarget !== null) {
+            var slotindex = this.slotTarget.siblings('th').text();
+            var mapparam = {
+                    "index": Number(slotindex),
+                    "status": null,
+                    "waferID": null
+                };
+            var action = "PUT" + $("#waferType").val();
+            var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), action, mapparam, null);
+            // AJAX POST
+            this.ajaxCall(this.ajaxUrl, json, "putStandard", this.callBack);
+        } else {
+            alert("Slot select fail.");
+        }
+    },
+
+    mapWaferTypeBtnCLick: function () {
+        // Build up JSON
+        var action = "MAP" + $("#waferType").val();
+        var json = encodeJSON("SCHD", "COMMAND", this.model.get('viewName'), action, null, null);
+        // AJAX POST
+        this.ajaxCall(this.ajaxUrl, json, "mapStandard", this.callBack);
+    },
+
+    // To be removed after wafer type change for all input view.
+    // START >>
     getStandardBtnCLick: function () {
         // Build up JSON
         if (this.slotTarget !== null) {
@@ -201,6 +262,7 @@ window.InputBaseView = window.BaseView.extend({
         // AJAX POST
         this.ajaxCall(this.ajaxUrl, json, "mapWrapAbove", this.callBack);
     },
+    // END <<
 
     slotClick: function (e) {
         this.slotTarget = $(e.currentTarget);
@@ -214,5 +276,27 @@ window.InputBaseView = window.BaseView.extend({
             this.slotTarget.parent().addClass('selected');
             console.log('inputBase: '+this.model.get('viewName')+', slot: '+ this.slotTarget.attr('id')+' selected.');
         }
+    },
+
+    slotIdDblCkick: function(e) {
+        var th = $(e.currentTarget);
+        th.find('label').hide();
+        th.find('input[type="text"]').show().focus();
+    },
+
+    slotIdDblCkick: function(e) {
+        var th = $(e.currentTarget);
+        th.find('.wafer-id').hide();
+        th.find('.wafer-id-input').val(th.find('.wafer-id').text());
+        th.find('.wafer-id-input').show().focus();
+        th.find('.wafer-id-input').select();
+    },
+
+    handleWaferIdChange: function(e) {
+        var text = $(e.currentTarget);
+        text.hide();
+        var th = $(e.currentTarget).parent();
+        th.find('.wafer-id').text(text.val());
+        th.find('.wafer-id').show();
     }
 });

--- a/ui/web/tpl/Input1View.html
+++ b/ui/web/tpl/Input1View.html
@@ -98,186 +98,20 @@
                 <table class="table table-condensed wafer-slots">
                     <thead>
                         <tr>
-                            <th width="20%">#</th>
+                            <th width="30%">#</th>
                             <th>SLOTS</th>
                         </tr>
                     </thead>
                     <tbody id="slots">
+                        <% for (var i=25; i > 0; i--) { %>
                         <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">25</label>
+                            <th scope="row"><%= i %></th>
+                            <td id="slot<%= i %>">
+                                <label class="control-label wafer-id"></label>
                                 <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot25"></td>
+                            </td>
                         </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">24</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot24"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">23</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot23"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">22</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot22"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">21</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot21"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">20</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot20"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">19</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot19"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">18</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot18"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">17</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot17"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">16</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot16"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">15</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot15"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">14</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot14"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">13</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot13"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">12</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot12"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">11</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot11"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">10</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot10"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">9</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot9"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">8</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot8"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">7</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot7"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">6</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot6"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">5</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot5"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">4</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot4"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">3</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot3"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">2</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot2"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label class="control-label wafer-id">1</label>
-                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
-                            </th>
-                            <td id="slot1"></td>
-                        </tr>
+                        <% } %>
                     </tbody>
                 </table>
             </div>

--- a/ui/web/tpl/Input1View.html
+++ b/ui/web/tpl/Input1View.html
@@ -11,28 +11,25 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Station</label>
+                            <label class="control-label col-xs-6" style="text-align:left;">Wafer Type</label>
                             <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>INPUT_1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Level</label>
-                            <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>1</option>
+                                <select class="form-control" id="waferType">
+                                    <option value="STANDARD">Standard</option>
+                                    <option value="THIN">Thin</option>
+                                    <option value="THICK">Thick</option>
+                                    <option value="WRAP BELOW">Wrap Below</option>
+                                    <option value="WRAP ABOVE">Wrap Above</option>
                                 </select>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="control-label col-xs-6 text-right" style="text-align:left;"><span>Cassette Type</span></label>
                             <div class="col-xs-6">
-                                <select class="form-control cassette-type">
-                                    <option>Standard</option>
-                                    <option>Thin</option>
-                                    <option>Thick</option>
+                                <select class="form-control cassette-type" id="cassette-type">
+                                    <option>25 Foup</option>
+                                    <option>13 Four</option>
+                                    <option>25 Cassette</option>
+                                    <option>13 Cassette</option>
                                 </select>
                             </div>
                         </div>
@@ -85,115 +82,200 @@
                             </div>
                         </div>
                     </form>
+                    <form action="" class="form-horizontal" role="form">
+                        <div class="form-group">
+                            <label class="control-label col-xs-6 text-right" style="text-align:left;">UPDATE</label>
+                            <div class="col-xs-6">
+                                <div class="btn-group">
+                                    <button class="btn btn-default btn-sm" id="updateId" type="button">UPDATE ID</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </div>
             </div>
             <div class="col-xs-4">
                 <table class="table table-condensed wafer-slots">
                     <thead>
                         <tr>
-                            <th>#</th>
+                            <th width="20%">#</th>
                             <th>SLOTS</th>
                         </tr>
                     </thead>
                     <tbody id="slots">
                         <tr>
-                            <th scope="row">25</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">25</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot25"></td>
                         </tr>
                         <tr>
-                            <th scope="row">24</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">24</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot24"></td>
                         </tr>
                         <tr>
-                            <th scope="row">23</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">23</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot23"></td>
                         </tr>
                         <tr>
-                            <th scope="row">22</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">22</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot22"></td>
                         </tr>
                         <tr>
-                            <th scope="row">21</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">21</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot21"></td>
                         </tr>
                         <tr>
-                            <th scope="row">20</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">20</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot20"></td>
                         </tr>
                         <tr>
-                            <th scope="row">19</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">19</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot19"></td>
                         </tr>
                         <tr>
-                            <th scope="row">18</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">18</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot18"></td>
                         </tr>
                         <tr>
-                            <th scope="row">17</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">17</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot17"></td>
                         </tr>
                         <tr>
-                            <th scope="row">16</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">16</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot16"></td>
                         </tr>
                         <tr>
-                            <th scope="row">15</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">15</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot15"></td>
                         </tr>
                         <tr>
-                            <th scope="row">14</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">14</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot14"></td>
                         </tr>
                         <tr>
-                            <th scope="row">13</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">13</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot13"></td>
                         </tr>
                         <tr>
-                            <th scope="row">12</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">12</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot12"></td>
                         </tr>
                         <tr>
-                            <th scope="row">11</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">11</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot11"></td>
                         </tr>
                         <tr>
-                            <th scope="row">10</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">10</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot10"></td>
                         </tr>
                         <tr>
-                            <th scope="row">9</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">9</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot9"></td>
                         </tr>
                         <tr>
-                            <th scope="row">8</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">8</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot8"></td>
                         </tr>
                         <tr>
-                            <th scope="row">7</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">7</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot7"></td>
                         </tr>
                         <tr>
-                            <th scope="row">6</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">6</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot6"></td>
                         </tr>
                         <tr>
-                            <th scope="row">5</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">5</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot5"></td>
                         </tr>
                         <tr>
-                            <th scope="row">4</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">4</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot4"></td>
                         </tr>
                         <tr>
-                            <th scope="row">3</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">3</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot3"></td>
                         </tr>
                         <tr>
-                            <th scope="row">2</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">2</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot2"></td>
                         </tr>
                         <tr>
-                            <th scope="row">1</th>
+                            <th scope="row">
+                                <label class="control-label wafer-id">1</label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </th>
                             <td id="slot1"></td>
                         </tr>
                     </tbody>
@@ -203,9 +285,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="getWaferTypeLabel">GET STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getStandard" type="button">GET STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="getWaferType" type="button">GET STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -213,9 +295,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="putWaferTypeLabel">PUT STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putStandard" type="button">PUT STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="putWaferType" type="button">PUT STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -223,69 +305,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="mapWaferTypeLabel">MAP STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapStandard" type="button">MAP STANDARD</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapBelow" type="button">GET WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapBelow" type="button">PUT WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapBelow" type="button">MAP WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapAbove" type="button">GET WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapAbove" type="button">PUT WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapAbove" type="button">MAP WRAP ABOVE</button>
+                                <button class="btn btn-default btn-sm" id="mapWaferType" type="button">MAP STANDARD</button>
                             </div>
                         </div>
                     </form>

--- a/ui/web/tpl/Input2View.html
+++ b/ui/web/tpl/Input2View.html
@@ -11,28 +11,25 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Station</label>
+                            <label class="control-label col-xs-6" style="text-align:left;">Wafer Type</label>
                             <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>INPUT_1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Level</label>
-                            <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>1</option>
+                                <select class="form-control" id="waferType">
+                                    <option value="STANDARD">Standard</option>
+                                    <option value="THIN">Thin</option>
+                                    <option value="THICK">Thick</option>
+                                    <option value="WRAP BELOW">Wrap Below</option>
+                                    <option value="WRAP ABOVE">Wrap Above</option>
                                 </select>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="control-label col-xs-6 text-right" style="text-align:left;"><span>Cassette Type</span></label>
                             <div class="col-xs-6">
-                                <select class="form-control cassette-type">
-                                    <option>Standard</option>
-                                    <option>Thin</option>
-                                    <option>Thick</option>
+                                <select class="form-control cassette-type" id="cassette-type">
+                                    <option>25 Foup</option>
+                                    <option>13 Four</option>
+                                    <option>25 Cassette</option>
+                                    <option>13 Cassette</option>
                                 </select>
                             </div>
                         </div>
@@ -44,7 +41,7 @@
                                 </div>
                                 <div>&nbsp;</div>
                                 <div class="btn-group">
-                                    <button class="btn btn-default btn-sm" id="closeFoup" type="button">Close FOUP</button>
+                                    <button class="btn btn-default btn-sm"id="closeFoup" type="button">Close FOUP</button>
                                 </div>
                             </div>
                         </div>
@@ -85,117 +82,36 @@
                             </div>
                         </div>
                     </form>
+                    <form action="" class="form-horizontal" role="form">
+                        <div class="form-group">
+                            <label class="control-label col-xs-6 text-right" style="text-align:left;">UPDATE</label>
+                            <div class="col-xs-6">
+                                <div class="btn-group">
+                                    <button class="btn btn-default btn-sm" id="updateId" type="button">UPDATE ID</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </div>
             </div>
             <div class="col-xs-4">
                 <table class="table table-condensed wafer-slots">
                     <thead>
                         <tr>
-                            <th>#</th>
+                            <th width="30%">#</th>
                             <th>SLOTS</th>
                         </tr>
                     </thead>
                     <tbody id="slots">
+                        <% for (var i=25; i > 0; i--) { %>
                         <tr>
-                            <th scope="row">25</th>
-                            <td id="slot25"></td>
+                            <th scope="row"><%= i %></th>
+                            <td id="slot<%= i %>">
+                                <label class="control-label wafer-id"></label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </td>
                         </tr>
-                        <tr>
-                            <th scope="row">24</th>
-                            <td id="slot24"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">23</th>
-                            <td id="slot23"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">22</th>
-                            <td id="slot22"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">21</th>
-                            <td id="slot21"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">20</th>
-                            <td id="slot20"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">19</th>
-                            <td id="slot19"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">18</th>
-                            <td id="slot18"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">17</th>
-                            <td id="slot17"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">16</th>
-                            <td id="slot16"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">15</th>
-                            <td id="slot15"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">14</th>
-                            <td id="slot14"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">13</th>
-                            <td id="slot13"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">12</th>
-                            <td id="slot12"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">11</th>
-                            <td id="slot11"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">10</th>
-                            <td id="slot10"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">9</th>
-                            <td id="slot9"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">8</th>
-                            <td id="slot8"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">7</th>
-                            <td id="slot7"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">6</th>
-                            <td id="slot6"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">5</th>
-                            <td id="slot5"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">4</th>
-                            <td id="slot4"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">3</th>
-                            <td id="slot3"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">2</th>
-                            <td id="slot2"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">1</th>
-                            <td id="slot1"></td>
-                        </tr>
+                        <% } %>
                     </tbody>
                 </table>
             </div>
@@ -203,9 +119,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="getWaferTypeLabel">GET STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getStandard" type="button">GET STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="getWaferType" type="button">GET STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -213,9 +129,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="putWaferTypeLabel">PUT STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putStandard" type="button">PUT STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="putWaferType" type="button">PUT STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -223,69 +139,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="mapWaferTypeLabel">MAP STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapStandard" type="button">MAP STANDARD</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapBelow" type="button">GET WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapBelow" type="button">PUT WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapBelow" type="button">MAP WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapAbove" type="button">GET WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapAbove" type="button">PUT WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapAbove" type="button">MAP WRAP ABOVE</button>
+                                <button class="btn btn-default btn-sm" id="mapWaferType" type="button">MAP STANDARD</button>
                             </div>
                         </div>
                     </form>

--- a/ui/web/tpl/Input3View.html
+++ b/ui/web/tpl/Input3View.html
@@ -11,28 +11,25 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Station</label>
+                            <label class="control-label col-xs-6" style="text-align:left;">Wafer Type</label>
                             <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>INPUT_1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Level</label>
-                            <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>1</option>
+                                <select class="form-control" id="waferType">
+                                    <option value="STANDARD">Standard</option>
+                                    <option value="THIN">Thin</option>
+                                    <option value="THICK">Thick</option>
+                                    <option value="WRAP BELOW">Wrap Below</option>
+                                    <option value="WRAP ABOVE">Wrap Above</option>
                                 </select>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="control-label col-xs-6 text-right" style="text-align:left;"><span>Cassette Type</span></label>
                             <div class="col-xs-6">
-                                <select class="form-control cassette-type">
-                                    <option>Standard</option>
-                                    <option>Thin</option>
-                                    <option>Thick</option>
+                                <select class="form-control cassette-type" id="cassette-type">
+                                    <option>25 Foup</option>
+                                    <option>13 Four</option>
+                                    <option>25 Cassette</option>
+                                    <option>13 Cassette</option>
                                 </select>
                             </div>
                         </div>
@@ -44,7 +41,7 @@
                                 </div>
                                 <div>&nbsp;</div>
                                 <div class="btn-group">
-                                    <button class="btn btn-default btn-sm" id="closeFoup" type="button">Close FOUP</button>
+                                    <button class="btn btn-default btn-sm"id="closeFoup" type="button">Close FOUP</button>
                                 </div>
                             </div>
                         </div>
@@ -85,117 +82,36 @@
                             </div>
                         </div>
                     </form>
+                    <form action="" class="form-horizontal" role="form">
+                        <div class="form-group">
+                            <label class="control-label col-xs-6 text-right" style="text-align:left;">UPDATE</label>
+                            <div class="col-xs-6">
+                                <div class="btn-group">
+                                    <button class="btn btn-default btn-sm" id="updateId" type="button">UPDATE ID</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </div>
             </div>
             <div class="col-xs-4">
                 <table class="table table-condensed wafer-slots">
                     <thead>
                         <tr>
-                            <th>#</th>
+                            <th width="30%">#</th>
                             <th>SLOTS</th>
                         </tr>
                     </thead>
                     <tbody id="slots">
+                        <% for (var i=25; i > 0; i--) { %>
                         <tr>
-                            <th scope="row">25</th>
-                            <td id="slot25"></td>
+                            <th scope="row"><%= i %></th>
+                            <td id="slot<%= i %>">
+                                <label class="control-label wafer-id"></label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </td>
                         </tr>
-                        <tr>
-                            <th scope="row">24</th>
-                            <td id="slot24"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">23</th>
-                            <td id="slot23"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">22</th>
-                            <td id="slot22"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">21</th>
-                            <td id="slot21"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">20</th>
-                            <td id="slot20"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">19</th>
-                            <td id="slot19"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">18</th>
-                            <td id="slot18"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">17</th>
-                            <td id="slot17"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">16</th>
-                            <td id="slot16"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">15</th>
-                            <td id="slot15"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">14</th>
-                            <td id="slot14"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">13</th>
-                            <td id="slot13"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">12</th>
-                            <td id="slot12"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">11</th>
-                            <td id="slot11"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">10</th>
-                            <td id="slot10"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">9</th>
-                            <td id="slot9"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">8</th>
-                            <td id="slot8"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">7</th>
-                            <td id="slot7"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">6</th>
-                            <td id="slot6"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">5</th>
-                            <td id="slot5"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">4</th>
-                            <td id="slot4"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">3</th>
-                            <td id="slot3"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">2</th>
-                            <td id="slot2"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">1</th>
-                            <td id="slot1"></td>
-                        </tr>
+                        <% } %>
                     </tbody>
                 </table>
             </div>
@@ -203,9 +119,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="getWaferTypeLabel">GET STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getStandard" type="button">GET STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="getWaferType" type="button">GET STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -213,9 +129,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="putWaferTypeLabel">PUT STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putStandard" type="button">PUT STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="putWaferType" type="button">PUT STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -223,69 +139,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="mapWaferTypeLabel">MAP STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapStandard" type="button">MAP STANDARD</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapBelow" type="button">GET WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapBelow" type="button">PUT WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapBelow" type="button">MAP WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapAbove" type="button">GET WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapAbove" type="button">PUT WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapAbove" type="button">MAP WRAP ABOVE</button>
+                                <button class="btn btn-default btn-sm" id="mapWaferType" type="button">MAP STANDARD</button>
                             </div>
                         </div>
                     </form>

--- a/ui/web/tpl/Input4View.html
+++ b/ui/web/tpl/Input4View.html
@@ -11,28 +11,25 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Station</label>
+                            <label class="control-label col-xs-6" style="text-align:left;">Wafer Type</label>
                             <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>INPUT_1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Level</label>
-                            <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>1</option>
+                                <select class="form-control" id="waferType">
+                                    <option value="STANDARD">Standard</option>
+                                    <option value="THIN">Thin</option>
+                                    <option value="THICK">Thick</option>
+                                    <option value="WRAP BELOW">Wrap Below</option>
+                                    <option value="WRAP ABOVE">Wrap Above</option>
                                 </select>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="control-label col-xs-6 text-right" style="text-align:left;"><span>Cassette Type</span></label>
                             <div class="col-xs-6">
-                                <select class="form-control cassette-type">
-                                    <option>Standard</option>
-                                    <option>Thin</option>
-                                    <option>Thick</option>
+                                <select class="form-control cassette-type" id="cassette-type">
+                                    <option>25 Foup</option>
+                                    <option>13 Four</option>
+                                    <option>25 Cassette</option>
+                                    <option>13 Cassette</option>
                                 </select>
                             </div>
                         </div>
@@ -44,7 +41,7 @@
                                 </div>
                                 <div>&nbsp;</div>
                                 <div class="btn-group">
-                                    <button class="btn btn-default btn-sm" id="closeFoup" type="button">Close FOUP</button>
+                                    <button class="btn btn-default btn-sm"id="closeFoup" type="button">Close FOUP</button>
                                 </div>
                             </div>
                         </div>
@@ -85,117 +82,36 @@
                             </div>
                         </div>
                     </form>
+                    <form action="" class="form-horizontal" role="form">
+                        <div class="form-group">
+                            <label class="control-label col-xs-6 text-right" style="text-align:left;">UPDATE</label>
+                            <div class="col-xs-6">
+                                <div class="btn-group">
+                                    <button class="btn btn-default btn-sm" id="updateId" type="button">UPDATE ID</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </div>
             </div>
             <div class="col-xs-4">
                 <table class="table table-condensed wafer-slots">
                     <thead>
                         <tr>
-                            <th>#</th>
+                            <th width="30%">#</th>
                             <th>SLOTS</th>
                         </tr>
                     </thead>
                     <tbody id="slots">
+                        <% for (var i=25; i > 0; i--) { %>
                         <tr>
-                            <th scope="row">25</th>
-                            <td id="slot25"></td>
+                            <th scope="row"><%= i %></th>
+                            <td id="slot<%= i %>">
+                                <label class="control-label wafer-id"></label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </td>
                         </tr>
-                        <tr>
-                            <th scope="row">24</th>
-                            <td id="slot24"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">23</th>
-                            <td id="slot23"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">22</th>
-                            <td id="slot22"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">21</th>
-                            <td id="slot21"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">20</th>
-                            <td id="slot20"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">19</th>
-                            <td id="slot19"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">18</th>
-                            <td id="slot18"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">17</th>
-                            <td id="slot17"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">16</th>
-                            <td id="slot16"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">15</th>
-                            <td id="slot15"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">14</th>
-                            <td id="slot14"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">13</th>
-                            <td id="slot13"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">12</th>
-                            <td id="slot12"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">11</th>
-                            <td id="slot11"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">10</th>
-                            <td id="slot10"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">9</th>
-                            <td id="slot9"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">8</th>
-                            <td id="slot8"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">7</th>
-                            <td id="slot7"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">6</th>
-                            <td id="slot6"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">5</th>
-                            <td id="slot5"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">4</th>
-                            <td id="slot4"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">3</th>
-                            <td id="slot3"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">2</th>
-                            <td id="slot2"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">1</th>
-                            <td id="slot1"></td>
-                        </tr>
+                        <% } %>
                     </tbody>
                 </table>
             </div>
@@ -203,9 +119,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="getWaferTypeLabel">GET STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getStandard" type="button">GET STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="getWaferType" type="button">GET STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -213,9 +129,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="putWaferTypeLabel">PUT STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putStandard" type="button">PUT STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="putWaferType" type="button">PUT STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -223,69 +139,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="mapWaferTypeLabel">MAP STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapStandard" type="button">MAP STANDARD</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapBelow" type="button">GET WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapBelow" type="button">PUT WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapBelow" type="button">MAP WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapAbove" type="button">GET WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapAbove" type="button">PUT WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapAbove" type="button">MAP WRAP ABOVE</button>
+                                <button class="btn btn-default btn-sm" id="mapWaferType" type="button">MAP STANDARD</button>
                             </div>
                         </div>
                     </form>

--- a/ui/web/tpl/Input5View.html
+++ b/ui/web/tpl/Input5View.html
@@ -11,28 +11,25 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Station</label>
+                            <label class="control-label col-xs-6" style="text-align:left;">Wafer Type</label>
                             <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>INPUT_1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Level</label>
-                            <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>1</option>
+                                <select class="form-control" id="waferType">
+                                    <option value="STANDARD">Standard</option>
+                                    <option value="THIN">Thin</option>
+                                    <option value="THICK">Thick</option>
+                                    <option value="WRAP BELOW">Wrap Below</option>
+                                    <option value="WRAP ABOVE">Wrap Above</option>
                                 </select>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="control-label col-xs-6 text-right" style="text-align:left;"><span>Cassette Type</span></label>
                             <div class="col-xs-6">
-                                <select class="form-control cassette-type">
-                                    <option>Standard</option>
-                                    <option>Thin</option>
-                                    <option>Thick</option>
+                                <select class="form-control cassette-type" id="cassette-type">
+                                    <option>25 Foup</option>
+                                    <option>13 Four</option>
+                                    <option>25 Cassette</option>
+                                    <option>13 Cassette</option>
                                 </select>
                             </div>
                         </div>
@@ -44,7 +41,7 @@
                                 </div>
                                 <div>&nbsp;</div>
                                 <div class="btn-group">
-                                    <button class="btn btn-default btn-sm" id="closeFoup" type="button">Close FOUP</button>
+                                    <button class="btn btn-default btn-sm"id="closeFoup" type="button">Close FOUP</button>
                                 </div>
                             </div>
                         </div>
@@ -85,117 +82,36 @@
                             </div>
                         </div>
                     </form>
+                    <form action="" class="form-horizontal" role="form">
+                        <div class="form-group">
+                            <label class="control-label col-xs-6 text-right" style="text-align:left;">UPDATE</label>
+                            <div class="col-xs-6">
+                                <div class="btn-group">
+                                    <button class="btn btn-default btn-sm" id="updateId" type="button">UPDATE ID</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </div>
             </div>
             <div class="col-xs-4">
                 <table class="table table-condensed wafer-slots">
                     <thead>
                         <tr>
-                            <th>#</th>
+                            <th width="30%">#</th>
                             <th>SLOTS</th>
                         </tr>
                     </thead>
                     <tbody id="slots">
+                        <% for (var i=25; i > 0; i--) { %>
                         <tr>
-                            <th scope="row">25</th>
-                            <td id="slot25"></td>
+                            <th scope="row"><%= i %></th>
+                            <td id="slot<%= i %>">
+                                <label class="control-label wafer-id"></label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </td>
                         </tr>
-                        <tr>
-                            <th scope="row">24</th>
-                            <td id="slot24"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">23</th>
-                            <td id="slot23"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">22</th>
-                            <td id="slot22"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">21</th>
-                            <td id="slot21"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">20</th>
-                            <td id="slot20"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">19</th>
-                            <td id="slot19"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">18</th>
-                            <td id="slot18"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">17</th>
-                            <td id="slot17"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">16</th>
-                            <td id="slot16"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">15</th>
-                            <td id="slot15"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">14</th>
-                            <td id="slot14"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">13</th>
-                            <td id="slot13"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">12</th>
-                            <td id="slot12"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">11</th>
-                            <td id="slot11"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">10</th>
-                            <td id="slot10"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">9</th>
-                            <td id="slot9"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">8</th>
-                            <td id="slot8"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">7</th>
-                            <td id="slot7"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">6</th>
-                            <td id="slot6"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">5</th>
-                            <td id="slot5"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">4</th>
-                            <td id="slot4"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">3</th>
-                            <td id="slot3"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">2</th>
-                            <td id="slot2"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">1</th>
-                            <td id="slot1"></td>
-                        </tr>
+                        <% } %>
                     </tbody>
                 </table>
             </div>
@@ -203,9 +119,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="getWaferTypeLabel">GET STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getStandard" type="button">GET STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="getWaferType" type="button">GET STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -213,9 +129,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="putWaferTypeLabel">PUT STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putStandard" type="button">PUT STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="putWaferType" type="button">PUT STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -223,69 +139,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="mapWaferTypeLabel">MAP STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapStandard" type="button">MAP STANDARD</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapBelow" type="button">GET WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapBelow" type="button">PUT WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapBelow" type="button">MAP WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapAbove" type="button">GET WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapAbove" type="button">PUT WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapAbove" type="button">MAP WRAP ABOVE</button>
+                                <button class="btn btn-default btn-sm" id="mapWaferType" type="button">MAP STANDARD</button>
                             </div>
                         </div>
                     </form>

--- a/ui/web/tpl/Input6View.html
+++ b/ui/web/tpl/Input6View.html
@@ -11,28 +11,25 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Station</label>
+                            <label class="control-label col-xs-6" style="text-align:left;">Wafer Type</label>
                             <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>INPUT_1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Level</label>
-                            <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>1</option>
+                                <select class="form-control" id="waferType">
+                                    <option value="STANDARD">Standard</option>
+                                    <option value="THIN">Thin</option>
+                                    <option value="THICK">Thick</option>
+                                    <option value="WRAP BELOW">Wrap Below</option>
+                                    <option value="WRAP ABOVE">Wrap Above</option>
                                 </select>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="control-label col-xs-6 text-right" style="text-align:left;"><span>Cassette Type</span></label>
                             <div class="col-xs-6">
-                                <select class="form-control cassette-type">
-                                    <option>Standard</option>
-                                    <option>Thin</option>
-                                    <option>Thick</option>
+                                <select class="form-control cassette-type" id="cassette-type">
+                                    <option>25 Foup</option>
+                                    <option>13 Four</option>
+                                    <option>25 Cassette</option>
+                                    <option>13 Cassette</option>
                                 </select>
                             </div>
                         </div>
@@ -44,7 +41,7 @@
                                 </div>
                                 <div>&nbsp;</div>
                                 <div class="btn-group">
-                                    <button class="btn btn-default btn-sm" id="closeFoup" type="button">Close FOUP</button>
+                                    <button class="btn btn-default btn-sm"id="closeFoup" type="button">Close FOUP</button>
                                 </div>
                             </div>
                         </div>
@@ -85,117 +82,36 @@
                             </div>
                         </div>
                     </form>
+                    <form action="" class="form-horizontal" role="form">
+                        <div class="form-group">
+                            <label class="control-label col-xs-6 text-right" style="text-align:left;">UPDATE</label>
+                            <div class="col-xs-6">
+                                <div class="btn-group">
+                                    <button class="btn btn-default btn-sm" id="updateId" type="button">UPDATE ID</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </div>
             </div>
             <div class="col-xs-4">
                 <table class="table table-condensed wafer-slots">
                     <thead>
                         <tr>
-                            <th>#</th>
+                            <th width="30%">#</th>
                             <th>SLOTS</th>
                         </tr>
                     </thead>
                     <tbody id="slots">
+                        <% for (var i=25; i > 0; i--) { %>
                         <tr>
-                            <th scope="row">25</th>
-                            <td id="slot25"></td>
+                            <th scope="row"><%= i %></th>
+                            <td id="slot<%= i %>">
+                                <label class="control-label wafer-id"></label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </td>
                         </tr>
-                        <tr>
-                            <th scope="row">24</th>
-                            <td id="slot24"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">23</th>
-                            <td id="slot23"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">22</th>
-                            <td id="slot22"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">21</th>
-                            <td id="slot21"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">20</th>
-                            <td id="slot20"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">19</th>
-                            <td id="slot19"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">18</th>
-                            <td id="slot18"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">17</th>
-                            <td id="slot17"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">16</th>
-                            <td id="slot16"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">15</th>
-                            <td id="slot15"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">14</th>
-                            <td id="slot14"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">13</th>
-                            <td id="slot13"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">12</th>
-                            <td id="slot12"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">11</th>
-                            <td id="slot11"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">10</th>
-                            <td id="slot10"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">9</th>
-                            <td id="slot9"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">8</th>
-                            <td id="slot8"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">7</th>
-                            <td id="slot7"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">6</th>
-                            <td id="slot6"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">5</th>
-                            <td id="slot5"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">4</th>
-                            <td id="slot4"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">3</th>
-                            <td id="slot3"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">2</th>
-                            <td id="slot2"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">1</th>
-                            <td id="slot1"></td>
-                        </tr>
+                        <% } %>
                     </tbody>
                 </table>
             </div>
@@ -203,9 +119,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="getWaferTypeLabel">GET STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getStandard" type="button">GET STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="getWaferType" type="button">GET STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -213,9 +129,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="putWaferTypeLabel">PUT STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putStandard" type="button">PUT STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="putWaferType" type="button">PUT STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -223,69 +139,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="mapWaferTypeLabel">MAP STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapStandard" type="button">MAP STANDARD</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapBelow" type="button">GET WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapBelow" type="button">PUT WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapBelow" type="button">MAP WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapAbove" type="button">GET WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapAbove" type="button">PUT WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapAbove" type="button">MAP WRAP ABOVE</button>
+                                <button class="btn btn-default btn-sm" id="mapWaferType" type="button">MAP STANDARD</button>
                             </div>
                         </div>
                     </form>

--- a/ui/web/tpl/Input7View.html
+++ b/ui/web/tpl/Input7View.html
@@ -11,28 +11,25 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Station</label>
+                            <label class="control-label col-xs-6" style="text-align:left;">Wafer Type</label>
                             <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>INPUT_1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Level</label>
-                            <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>1</option>
+                                <select class="form-control" id="waferType">
+                                    <option value="STANDARD">Standard</option>
+                                    <option value="THIN">Thin</option>
+                                    <option value="THICK">Thick</option>
+                                    <option value="WRAP BELOW">Wrap Below</option>
+                                    <option value="WRAP ABOVE">Wrap Above</option>
                                 </select>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="control-label col-xs-6 text-right" style="text-align:left;"><span>Cassette Type</span></label>
                             <div class="col-xs-6">
-                                <select class="form-control cassette-type">
-                                    <option>Standard</option>
-                                    <option>Thin</option>
-                                    <option>Thick</option>
+                                <select class="form-control cassette-type" id="cassette-type">
+                                    <option>25 Foup</option>
+                                    <option>13 Four</option>
+                                    <option>25 Cassette</option>
+                                    <option>13 Cassette</option>
                                 </select>
                             </div>
                         </div>
@@ -44,7 +41,7 @@
                                 </div>
                                 <div>&nbsp;</div>
                                 <div class="btn-group">
-                                    <button class="btn btn-default btn-sm" id="closeFoup" type="button">Close FOUP</button>
+                                    <button class="btn btn-default btn-sm"id="closeFoup" type="button">Close FOUP</button>
                                 </div>
                             </div>
                         </div>
@@ -85,117 +82,36 @@
                             </div>
                         </div>
                     </form>
+                    <form action="" class="form-horizontal" role="form">
+                        <div class="form-group">
+                            <label class="control-label col-xs-6 text-right" style="text-align:left;">UPDATE</label>
+                            <div class="col-xs-6">
+                                <div class="btn-group">
+                                    <button class="btn btn-default btn-sm" id="updateId" type="button">UPDATE ID</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </div>
             </div>
             <div class="col-xs-4">
                 <table class="table table-condensed wafer-slots">
                     <thead>
                         <tr>
-                            <th>#</th>
+                            <th width="30%">#</th>
                             <th>SLOTS</th>
                         </tr>
                     </thead>
                     <tbody id="slots">
+                        <% for (var i=25; i > 0; i--) { %>
                         <tr>
-                            <th scope="row">25</th>
-                            <td id="slot25"></td>
+                            <th scope="row"><%= i %></th>
+                            <td id="slot<%= i %>">
+                                <label class="control-label wafer-id"></label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </td>
                         </tr>
-                        <tr>
-                            <th scope="row">24</th>
-                            <td id="slot24"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">23</th>
-                            <td id="slot23"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">22</th>
-                            <td id="slot22"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">21</th>
-                            <td id="slot21"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">20</th>
-                            <td id="slot20"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">19</th>
-                            <td id="slot19"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">18</th>
-                            <td id="slot18"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">17</th>
-                            <td id="slot17"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">16</th>
-                            <td id="slot16"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">15</th>
-                            <td id="slot15"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">14</th>
-                            <td id="slot14"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">13</th>
-                            <td id="slot13"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">12</th>
-                            <td id="slot12"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">11</th>
-                            <td id="slot11"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">10</th>
-                            <td id="slot10"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">9</th>
-                            <td id="slot9"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">8</th>
-                            <td id="slot8"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">7</th>
-                            <td id="slot7"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">6</th>
-                            <td id="slot6"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">5</th>
-                            <td id="slot5"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">4</th>
-                            <td id="slot4"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">3</th>
-                            <td id="slot3"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">2</th>
-                            <td id="slot2"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">1</th>
-                            <td id="slot1"></td>
-                        </tr>
+                        <% } %>
                     </tbody>
                 </table>
             </div>
@@ -203,9 +119,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="getWaferTypeLabel">GET STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getStandard" type="button">GET STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="getWaferType" type="button">GET STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -213,9 +129,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="putWaferTypeLabel">PUT STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putStandard" type="button">PUT STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="putWaferType" type="button">PUT STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -223,69 +139,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="mapWaferTypeLabel">MAP STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapStandard" type="button">MAP STANDARD</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapBelow" type="button">GET WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapBelow" type="button">PUT WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapBelow" type="button">MAP WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapAbove" type="button">GET WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapAbove" type="button">PUT WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapAbove" type="button">MAP WRAP ABOVE</button>
+                                <button class="btn btn-default btn-sm" id="mapWaferType" type="button">MAP STANDARD</button>
                             </div>
                         </div>
                     </form>

--- a/ui/web/tpl/Input8View.html
+++ b/ui/web/tpl/Input8View.html
@@ -11,28 +11,25 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Station</label>
+                            <label class="control-label col-xs-6" style="text-align:left;">Wafer Type</label>
                             <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>INPUT_1</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">Level</label>
-                            <div class="col-xs-6">
-                                <select class="form-control">
-                                    <option>1</option>
+                                <select class="form-control" id="waferType">
+                                    <option value="STANDARD">Standard</option>
+                                    <option value="THIN">Thin</option>
+                                    <option value="THICK">Thick</option>
+                                    <option value="WRAP BELOW">Wrap Below</option>
+                                    <option value="WRAP ABOVE">Wrap Above</option>
                                 </select>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="control-label col-xs-6 text-right" style="text-align:left;"><span>Cassette Type</span></label>
                             <div class="col-xs-6">
-                                <select class="form-control cassette-type">
-                                    <option>Standard</option>
-                                    <option>Thin</option>
-                                    <option>Thick</option>
+                                <select class="form-control cassette-type" id="cassette-type">
+                                    <option>25 Foup</option>
+                                    <option>13 Four</option>
+                                    <option>25 Cassette</option>
+                                    <option>13 Cassette</option>
                                 </select>
                             </div>
                         </div>
@@ -44,7 +41,7 @@
                                 </div>
                                 <div>&nbsp;</div>
                                 <div class="btn-group">
-                                    <button class="btn btn-default btn-sm" id="closeFoup" type="button">Close FOUP</button>
+                                    <button class="btn btn-default btn-sm"id="closeFoup" type="button">Close FOUP</button>
                                 </div>
                             </div>
                         </div>
@@ -85,117 +82,36 @@
                             </div>
                         </div>
                     </form>
+                    <form action="" class="form-horizontal" role="form">
+                        <div class="form-group">
+                            <label class="control-label col-xs-6 text-right" style="text-align:left;">UPDATE</label>
+                            <div class="col-xs-6">
+                                <div class="btn-group">
+                                    <button class="btn btn-default btn-sm" id="updateId" type="button">UPDATE ID</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </div>
             </div>
             <div class="col-xs-4">
                 <table class="table table-condensed wafer-slots">
                     <thead>
                         <tr>
-                            <th>#</th>
+                            <th width="30%">#</th>
                             <th>SLOTS</th>
                         </tr>
                     </thead>
                     <tbody id="slots">
+                        <% for (var i=25; i > 0; i--) { %>
                         <tr>
-                            <th scope="row">25</th>
-                            <td id="slot25"></td>
+                            <th scope="row"><%= i %></th>
+                            <td id="slot<%= i %>">
+                                <label class="control-label wafer-id"></label>
+                                <input type="text" class="form-control wafer-id-input" style="display:none;" />
+                            </td>
                         </tr>
-                        <tr>
-                            <th scope="row">24</th>
-                            <td id="slot24"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">23</th>
-                            <td id="slot23"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">22</th>
-                            <td id="slot22"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">21</th>
-                            <td id="slot21"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">20</th>
-                            <td id="slot20"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">19</th>
-                            <td id="slot19"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">18</th>
-                            <td id="slot18"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">17</th>
-                            <td id="slot17"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">16</th>
-                            <td id="slot16"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">15</th>
-                            <td id="slot15"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">14</th>
-                            <td id="slot14"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">13</th>
-                            <td id="slot13"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">12</th>
-                            <td id="slot12"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">11</th>
-                            <td id="slot11"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">10</th>
-                            <td id="slot10"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">9</th>
-                            <td id="slot9"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">8</th>
-                            <td id="slot8"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">7</th>
-                            <td id="slot7"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">6</th>
-                            <td id="slot6"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">5</th>
-                            <td id="slot5"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">4</th>
-                            <td id="slot4"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">3</th>
-                            <td id="slot3"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">2</th>
-                            <td id="slot2"></td>
-                        </tr>
-                        <tr>
-                            <th scope="row">1</th>
-                            <td id="slot1"></td>
-                        </tr>
+                        <% } %>
                     </tbody>
                 </table>
             </div>
@@ -203,9 +119,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="getWaferTypeLabel">GET STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getStandard" type="button">GET STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="getWaferType" type="button">GET STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -213,9 +129,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="putWaferTypeLabel">PUT STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putStandard" type="button">PUT STANDARD</button>
+                                <button class="btn btn-default btn-sm" id="putWaferType" type="button">PUT STANDARD</button>
                             </div>
                         </div>
                     </form>
@@ -223,69 +139,9 @@
                 <div>
                     <form action="" class="form-horizontal" role="form">
                         <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP STANDARD</label>
+                            <label class="control-label col-xs-6" style="text-align:left;" id="mapWaferTypeLabel">MAP STANDARD</label>
                             <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapStandard" type="button">MAP STANDARD</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapBelow" type="button">GET WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapBelow" type="button">PUT WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP BELOW</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapBelow" type="button">MAP WRAP BELOW</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">GET WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="getWrapAbove" type="button">GET WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">PUT WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="putWrapAbove" type="button">PUT WRAP ABOVE</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-                <div>
-                    <form action="" class="form-horizontal" role="form">
-                        <div class="form-group">
-                            <label class="control-label col-xs-6" style="text-align:left;">MAP WRAP ABOVE</label>
-                            <div class="col-xs-6">
-                                <button class="btn btn-default btn-sm" id="mapWrapAbove" type="button">MAP WRAP ABOVE</button>
+                                <button class="btn btn-default btn-sm" id="mapWaferType" type="button">MAP STANDARD</button>
                             </div>
                         </div>
                     </form>


### PR DESCRIPTION
- Change right section to "MAP", "GET" and "PUT". each section will display only the buttons for the wafer type selected
- single select on slot, not multiple select
- remove station on the top left
- change "level" to "wafer type" the options are "standard", "thick", "thin", "wrap below", wrap above"
- cassette type options are "25 Foup", "13 Four", "25 Cassette" and "13 Cassette"
- wafer type info should bind with "GET', "PUT" and "MAP" when sending out to SCHD
- add "updateID" button at bottom left
- enable typing in wafer id in slot table
